### PR TITLE
[AUTH-02] Add register endpoint with validation, bcrypt and Zod

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,12 +14,16 @@
   },
   "dependencies": {
     "@types/node": "^25.5.0",
+    "bcrypt": "^6.0.0",
+    "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "pg": "^8.20.0",
     "ts-node": "^10.9.2",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.6",
     "@types/pg": "^8.20.0",
     "dotenv-cli": "^11.0.0",

--- a/backend/src/controller/authentication.controller.ts
+++ b/backend/src/controller/authentication.controller.ts
@@ -1,0 +1,35 @@
+import type { Request, Response, NextFunction } from 'express';
+import { createUser, findUserByEmail } from '../models/user.model.js'
+import * as z from "zod";
+import bcrypt from 'bcrypt';
+
+const validationUser = z.object({
+    email: z.email(),
+    password: z.string().min(8)
+});
+
+async function hashPassword(plainPassword: string) {
+    const saltRounds = 12
+    return await bcrypt.hash(plainPassword, saltRounds)
+}
+
+export const registerUser = async (req: Request, res: Response, next: NextFunction) => {
+
+    try {
+        const result = validationUser.safeParse(req.body)
+        if (!result.success) {
+            res.status(400).json(result.error)
+        } else {
+            const existingUser = await findUserByEmail(result.data.email);
+            if (existingUser) {
+                return res.status(409).json('email already exist');
+            }
+            const hashedPassword = await hashPassword(result.data.password)
+            const newUser = await createUser({ email: result.data.email, password: hashedPassword })
+            res.status(201).json(newUser)
+        }
+
+    } catch (error) {
+        next(error);
+    }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,13 +1,22 @@
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path'; 
 import express from 'express';
+import register from "./routes/authentication.routes.js"
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+dotenv.config({ path: resolve(__dirname, '../../.env') });
 
 const app = express();
 const PORT = process.env.PORT ?? 3000;
-
 app.use(express.json());
 
 app.get('/health', (_req, res) => {
     res.json({ status: 'ok' });
 });
+
+app.use('/auth', register);
 
 app.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);

--- a/backend/src/models/db.ts
+++ b/backend/src/models/db.ts
@@ -2,8 +2,15 @@ import pg from 'pg';
 
 const { Pool } = pg;
 
-const pool = new Pool({
-    connectionString: process.env.DATABASE_URL,
-});
+let pool: InstanceType<typeof Pool> | null = null;
 
-export default pool;
+const getPool = () => {
+    if (!pool) {
+        pool = new Pool({
+            connectionString: process.env.DATABASE_URL,
+        });
+    }
+    return pool;
+};
+
+export default getPool;

--- a/backend/src/models/user.model.ts
+++ b/backend/src/models/user.model.ts
@@ -1,8 +1,8 @@
-import pool from './db.js';
+import getPool from './db.js';
 import type { User, CreateUserDTO, UserResponse } from '../types/user.types.js';
 
 export const createUser = async (data: CreateUserDTO): Promise<UserResponse> => {
-const result = await pool.query<User>(
+const result = await getPool().query<User>(
     `INSERT INTO users (email, password_hash)
     VALUES ($1, $2)
     RETURNING id, email`,
@@ -13,7 +13,7 @@ return result.rows[0] as UserResponse;
 };
 
 export const findUserByEmail = async (email: string): Promise<User | null> => {
-const result = await pool.query<User>(
+const result = await getPool().query<User>(
     `SELECT * FROM users WHERE email = $1`,
     [email]
 );

--- a/backend/src/routes/authentication.routes.ts
+++ b/backend/src/routes/authentication.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { registerUser } from "../controller/authentication.controller.js"
+
+const router = Router();
+
+router.post('/register', registerUser);
+
+export default router;

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -182,6 +182,13 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
+"@types/bcrypt@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/bcrypt/-/bcrypt-6.0.0.tgz#0d20587924663607fb59ae373d3d6fbc7b339a92"
+  integrity sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/body-parser@*":
   version "1.19.6"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.6.tgz#1859bebb8fd7dac9918a45d54c1971ab8b5af474"
@@ -303,6 +310,14 @@ balanced-match@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
   integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
+bcrypt@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-6.0.0.tgz#86643fddde9bcd0ad91400b063003fa4b0312835"
+  integrity sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==
+  dependencies:
+    node-addon-api "^8.3.0"
+    node-gyp-build "^4.8.4"
 
 body-parser@^2.2.1:
   version "2.2.2"
@@ -441,7 +456,7 @@ dotenv@^16.4.5:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
   integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
 
-dotenv@^17.1.0:
+dotenv@^17.1.0, dotenv@^17.3.1:
   version "17.3.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.3.1.tgz#2706f5b0165e45a1503348187b8468f87fe6aae2"
   integrity sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==
@@ -786,6 +801,16 @@ negotiator@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-1.0.0.tgz#b6c91bb47172d69f93cfd7c357bbb529019b5f6a"
   integrity sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==
+
+node-addon-api@^8.3.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.7.0.tgz#f64f8413456ecbe900221305a3f883c37666473f"
+  integrity sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==
+
+node-gyp-build@^4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
+  integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
 node-pg-migrate@^8.0.4:
   version "8.0.4"
@@ -1212,3 +1237,8 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+zod@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
+  integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==


### PR DESCRIPTION
## Changes
- Endpoint POST /auth/register
- Validation des données avec Zod (email format, password min 8)
- Hash du mot de passe avec bcrypt (saltRounds: 12)
- Retourne 201 + { id, email } en cas de succès
- Retourne 409 si email déjà utilisé
- Retourne 400 si données invalides
- Lazy initialization du Pool PostgreSQL

## Ticket
Closes #AUTH-02