### PR TITLE
feat[AUTH-04]: add JWT auth middleware

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,7 +2,8 @@ import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import express from 'express';
-import authRouter from "./routes/authentication.routes.js"
+import authRoutes from "./routes/authentication.routes.js"
+import { verifToken } from './middleware/authMiddleware.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -16,7 +17,8 @@ app.get('/health', (_req, res) => {
     res.json({ status: 'ok' });
 });
 
-app.use('/auth', authRouter);
+app.use('/auth', authRoutes);
+app.use(verifToken);
 
 
 app.listen(PORT, () => {

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -1,0 +1,17 @@
+import type { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+
+export const verifToken = (req: Request, res: Response, next: NextFunction) => {
+    const authorizationHeader = req.headers.authorization;
+    const token = authorizationHeader?.split(" ")[1];
+    if (!token) return res.status(401).json({ error: 'Token invalid or missing' });
+    try {
+        let decoded = jwt.verify(token, process.env.JWT_SECRET as string);
+        if (typeof decoded === "object") {
+            req.user = decoded as { id: string; email: string; };
+        }
+        next();
+    } catch (error) {
+        next(error);
+    }
+}

--- a/backend/src/types/src/types/express.d.ts
+++ b/backend/src/types/src/types/express.d.ts
@@ -1,0 +1,12 @@
+import "express";
+
+declare global {
+    namespace Express {
+        interface Request {
+            user: {
+                id: string;
+                email: string;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes
- Middleware `requireAuth` extrayant le token du header Authorization
- Extraction du token via parsing du format `Bearer <token>`
- Vérification du token avec `jwt.verify()`
- Injection de `req.user` avec `{ id, email }` sur la requête
- Retourne 401 si token absent ou invalide
- Extension de l'interface `Request` Express via `src/types/express.d.ts`
- Appliqué sur toutes les routes hors `/auth/*`

## Ticket
Closes #AUTH-04