### PR TITLE
feat[AUTH-06]: add login page with JWT storage

### DIFF
--- a/backend/src/controller/authentication.controller.ts
+++ b/backend/src/controller/authentication.controller.ts
@@ -56,9 +56,9 @@ export const logInUser = async (req: Request, res: Response, next: NextFunction)
                 return res.status(401).json(result.error)
             }
             // générer un JWT avec jwt.sign()
-            const jtwToken = jtw.sign({ id: existingUser.id, email: existingUser.email }, process.env.JWT_SECRET as string, { expiresIn: "7d" })
+            const jwtToken = jtw.sign({ id: existingUser.id, email: existingUser.email }, process.env.JWT_SECRET as string, { expiresIn: "7d" })
             // sinon statut 200 + token + user: { id, email }
-            res.status(200).json({ jtwToken, user: { id: existingUser.id, email: existingUser.email } })
+            res.status(200).json({ jwtToken, user: { id: existingUser.id, email: existingUser.email } })
         }
     } catch (error) {
         next(error);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,13 @@
 import { Routes, Route } from 'react-router-dom'
 import { Register } from './pages/Register'
 import Dashboard from './pages/Dashboard'
+import { Login } from './pages/Login'
 
 function App() {
   return (
     <Routes>
       <Route path="/register" element={<Register />} />
+      <Route path="/login" element={<Login />} />
       <Route path="/dashboard" element={<Dashboard />} />
     </Routes>
   )

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react"
+import { login } from "../services/auth.services"
+import axios from "axios"
+import { Link, useNavigate } from "react-router-dom"
+
+
+export function Login() {
+    //sate
+    const [formData, setFormData] = useState({
+        email: '',
+        password: '',
+    })
+
+    const [error, setError] = useState('')
+    const navigate = useNavigate()
+
+
+    //comportements
+    const handleSubmit = async (event: React.SubmitEvent<HTMLFormElement>) => {
+        event.preventDefault()
+        try {
+            const response = await login(formData)
+            console.log(response.data)
+            localStorage.setItem('token', response.data.jwtToken)
+            navigate('/dashboard')
+        } catch (err) {
+            if (axios.isAxiosError(err)) {
+                setError(err.response?.data)
+            }
+        }
+    }
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setFormData({ ...formData, [event.target.name]: event.target.value })
+    }
+
+
+    //render
+    return <>
+        <form onSubmit={handleSubmit}>
+            <input name="email" type="email" onChange={handleChange} value={formData.email} />
+            <input name="password" type="password" onChange={handleChange} value={formData.password} />
+            <button>Connexion</button>
+        </form>
+        {error}
+        <Link to="/register">Pas encore de compte ? S'inscrire</Link>
+    </>
+}
+

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import { useState } from "react"
 import { register } from "../services/auth.services"
 import axios from "axios"
 import { Link, useNavigate } from "react-router-dom"

--- a/frontend/src/services/auth.services.ts
+++ b/frontend/src/services/auth.services.ts
@@ -3,3 +3,7 @@ import axios from 'axios'
 export const register = async (data: { email: string; password: string }) => {
     return await axios.post('http://localhost:3000/auth/register', { email: data.email, password: data.password })
 }
+
+export const login = async (data: { email: string; password: string }) => {
+    return await axios.post('http://localhost:3000/auth/login', { email: data.email, password: data.password })
+}


### PR DESCRIPTION
## Changes
- Création de la page Login avec formulaire (email, password)
- Appel API POST /auth/login via axios (auth.service.ts)
- Stockage du JWT dans localStorage après connexion réussie
- Redirection vers /dashboard après connexion réussie
- Affichage des erreurs retournées par l'API
- Lien vers la page d'inscription via React Router
- Correction typo jtwToken → jwtToken côté backend

## Ticket
Closes #AUTH-06