### PR TITLE
feat[CAT-01] Add predefined list of categories and endpoint GET /api/v1/categories

### DIFF
--- a/backend/migrations/1776090760190_categories-predefined.js
+++ b/backend/migrations/1776090760190_categories-predefined.js
@@ -1,0 +1,55 @@
+import { type } from "node:os";
+
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+export const shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+export const up = (pgm) => {
+	pgm.alterColumn("categories", "user_id", {
+		notNull: false,
+	});
+	pgm.addColumn("categories", {
+		type: {
+			type: "varchar(50)",
+			notNull: true,
+			default: "non-essentielle",
+		},
+	});
+	pgm.sql(`
+			INSERT INTO categories (name, type, user_id) VALUES
+			('Courses', 'essentielle', NULL),
+			('Loyer / Logement', 'essentielle', NULL),
+			('Transport', 'essentielle', NULL),
+			('Santé', 'essentielle', NULL),
+			('Factures & Abonnement', 'essentielle', NULL),
+			('Maison', 'essentielle', NULL),
+			('Voiture', 'essentielle', NULL),
+			('Restaurants & Cafés', 'non-essentielle', NULL),
+			('Shopping', 'non-essentielle', NULL),
+			('Divertissement', 'non-essentielle', NULL),
+			('Voyages', 'non-essentielle', NULL),
+			('Sport & Bien-être', 'non-essentielle', NULL),
+			('Animaux', 'non-essentielle', NULL),
+			('Cadeaux', 'non-essentielle', NULL),
+			('Épargne', 'non-essentielle', NULL)
+		`);
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+export const down = (pgm) => {
+  pgm.sql(` DELETE FROM categories WHERE user_id IS NULL`);
+  pgm.dropColumn("categories", "type");
+  pgm.alterColumn("categories", "user_id", {
+    notNull: true,
+  });
+};

--- a/backend/src/controller/budget.controller.ts
+++ b/backend/src/controller/budget.controller.ts
@@ -9,7 +9,7 @@ export const registerBudget = async (req: Request, res: Response, next: NextFunc
             return res.status(400).json('invalid data');
         } else {
             const userId = req.user.id
-            const newBudget = await createBudget({ user_id: userId, amount: result.data?.amount, month: result.data?.month })
+            const newBudget = await createBudget({user_id: userId , amount: result.data.amount, month: result.data?.month })
             res.status(201).json(newBudget)
         }
     } catch (error) {

--- a/backend/src/controller/categories.controller.ts
+++ b/backend/src/controller/categories.controller.ts
@@ -1,0 +1,13 @@
+import type { Request, Response, NextFunction } from 'express';
+import { findCategoryByUserId } from "../models/categories.model.js";
+
+export const getCategories = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.user.id
+        const listCategories = await findCategoryByUserId(userId)
+        res.status(200).json({ list: listCategories })
+    } catch (error) {
+        next(error);
+    }
+}
+

--- a/backend/src/controller/expense.controller.ts
+++ b/backend/src/controller/expense.controller.ts
@@ -1,0 +1,18 @@
+import type { Request, Response, NextFunction } from 'express';
+import { validationExpense } from '../validator/expense.validator.js';
+import { createExpense } from '../models/expense.model.js';
+
+export const registerExpense = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const result = validationExpense.safeParse(req.body)
+        if (!result.success) {
+            return res.status(400).json('invalid data');
+        } else {
+            const userId = req.user.id
+            const newExpense = await createExpense({ user_id: userId, category_id: result.data.category_id, amount: result.data.amount, description: result.data.description ?? '', date: result.data.date })
+            res.status(201).json(newExpense)
+        }
+    } catch (error) {
+        next(error);
+    }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,7 @@ import express from 'express';
 import authRoutes from "./routes/authentication.routes.js"
 import { verifToken } from './middleware/authMiddleware.js';
 import budgetsRoutes from "./routes/budget.routes.js"
+import expensesRoutes from "./routes/expense.routes.js"
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -24,6 +25,7 @@ app.get('/health', (_req, res) => {
 app.use('/auth', authRoutes);
 app.use(verifToken);
 app.use('/api/v1', budgetsRoutes);
+app.use('/api/v1', expensesRoutes);
 
 
 app.listen(PORT, () => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import authRoutes from "./routes/authentication.routes.js"
 import { verifToken } from './middleware/authMiddleware.js';
 import budgetsRoutes from "./routes/budget.routes.js"
 import expensesRoutes from "./routes/expense.routes.js"
+import categoriesRoutes from "./routes/categories.routes.js"
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -26,6 +27,7 @@ app.use('/auth', authRoutes);
 app.use(verifToken);
 app.use('/api/v1', budgetsRoutes);
 app.use('/api/v1', expensesRoutes);
+app.use('/api/v1', categoriesRoutes);
 
 
 app.listen(PORT, () => {

--- a/backend/src/models/categories.model.ts
+++ b/backend/src/models/categories.model.ts
@@ -1,0 +1,11 @@
+import type { Category, CategoryResponse } from '../types/categories.type.js';
+import getPool from './db.js';
+
+export const findCategoryByUserId = async (user_id: string): Promise<Array<CategoryResponse>> => {
+    const result = await getPool().query<CategoryResponse>(
+        `SELECT id, type, name FROM categories WHERE user_id IS NULL OR user_id = $1`,
+        [user_id]
+    );
+
+    return result.rows;
+};

--- a/backend/src/models/expense.model.ts
+++ b/backend/src/models/expense.model.ts
@@ -1,0 +1,21 @@
+import type { Expense, CreateExpenseDTO, ExpenseResponse } from '../types/expense.types.js';
+import getPool from './db.js';
+
+export const createExpense = async (data: CreateExpenseDTO): Promise<ExpenseResponse> => {
+    const result = await getPool().query<Expense>(
+        `INSERT INTO expenses (user_id, category_id, amount, description, date)
+    VALUES ($1, $2, $3, $4, $5)
+    RETURNING id, category_id, amount, description, date`,
+        [data.user_id, data.category_id, data.amount, data.description, data.date]
+    );
+    return result.rows[0] as ExpenseResponse;
+}
+
+export const findExpenseByUserId = async (user_id: string): Promise<Expense | null> => {
+    const result = await getPool().query<Expense>(
+        `SELECT * FROM expenses WHERE user_id = $1`,
+        [user_id]
+    );
+
+    return result.rows[0] ?? null;
+};

--- a/backend/src/routes/categories.routes.ts
+++ b/backend/src/routes/categories.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { getCategories } from "../controller/categories.controller.js";
+
+const router = Router();
+
+router.get('/categories', getCategories);
+
+export default router;

--- a/backend/src/routes/expense.routes.ts
+++ b/backend/src/routes/expense.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { registerExpense } from "../controller/expense.controller.js";
+
+const router = Router();
+
+router.post('/expenses', registerExpense);
+
+export default router;

--- a/backend/src/types/categories.type.ts
+++ b/backend/src/types/categories.type.ts
@@ -1,0 +1,13 @@
+export type Category = {
+    id:string,
+    user_id: string | null,
+    type: 'essentielle' | 'non-essentielle',
+    name:string,
+    created_at: Date
+}
+
+export type CategoryResponse = {
+    id: string,
+    type: 'essentielle' | 'non-essentielle',
+    name: string,
+}

--- a/backend/src/types/expense.types.ts
+++ b/backend/src/types/expense.types.ts
@@ -1,0 +1,26 @@
+export type Expense = {
+    id: string;
+    user_id: string;
+    category_id: string;
+    amount: number;
+    description?: string;
+    date: string;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type CreateExpenseDTO = {
+    user_id: string;
+    category_id: string;
+    amount: number;
+    description?: string;
+    date: string;
+};
+
+export type ExpenseResponse = {
+    id: string;
+    category_id: string;
+    amount: number;
+    description?: string;
+    date: string;
+};

--- a/backend/src/validator/expense.validator.ts
+++ b/backend/src/validator/expense.validator.ts
@@ -1,0 +1,8 @@
+import * as z from "zod";
+
+export const validationExpense = z.object({
+    category_id: z.string(),
+    amount: z.number(),
+    description: z.string().max(255).optional(),
+    date: z.string(),
+})


### PR DESCRIPTION
## Changes

- Ajout colonne type + catégories prédéfinies
- Migration des modification avec `yarn migrate:up` en lien avec le ticket [XPNS-01] en attente de test car categories manquantes
- Ajout de l'endpoint GET /api/v1/categories
- Création des types TypeScript (Category, CategoryResponse)
- Création du modèle categories avec requête SQL qui retourne la liste des catégories par défaut 
- Route protégée par le middleware JWT
- Retourne 200+ { [les des categories] }


## Ticket
Closes #CAT-01