### PR TITLE
feat[XPNS-03] add GET /api/v1/expenses/summary/:month

### DIFF
--- a/backend/src/controller/expense.controller.ts
+++ b/backend/src/controller/expense.controller.ts
@@ -1,6 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { validationExpense } from '../validator/expense.validator.js';
-import { createExpense, findListExpenseByMonth } from '../models/expense.model.js';
+import { createExpense, findListExpenseByCategories, findListExpenseByMonth } from '../models/expense.model.js';
 
 export const registerExpense = async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -27,6 +27,21 @@ export const getExpensesByMonth = async (req: Request, res: Response, next: Next
         }
         const listExpense = await findListExpenseByMonth(userId, getMonth)
         res.status(200).json(listExpense)
+    } catch (error) {
+        next(error);
+    }
+}
+
+export const getExpensesByCategories = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const userId = req.user.id
+        const getMonth = req.params.month as string;
+        const regexDate = /^\d{4}-\d{2}$/
+        if (!regexDate.test(getMonth)) {
+            return res.status(400).json('date format is invalid (expected : YYYY-MM)');
+        }
+        const listExpenseByCategories = await findListExpenseByCategories(userId, getMonth)
+        res.status(200).json(listExpenseByCategories)
     } catch (error) {
         next(error);
     }

--- a/backend/src/models/expense.model.ts
+++ b/backend/src/models/expense.model.ts
@@ -2,7 +2,8 @@ import type {
     Expense,
     CreateExpenseDTO,
     ExpenseResponse,
-    ExpenseItem
+    ExpenseItem,
+    ExpenseByCategoryItem
 } from '../types/expense.types.js';
 import getPool from './db.js';
 
@@ -42,6 +43,19 @@ export const findListExpenseByMonth = async (user_id: string, month: string): Pr
         INNER JOIN categories ON expenses.category_id = categories.id
         WHERE expenses.user_id = $1 AND TO_CHAR(date, 'YYYY-MM') = $2
         ORDER BY date DESC`,
+        [user_id, month]
+    );
+    return result.rows;
+};
+
+export const findListExpenseByCategories = async (user_id: string, month: string): Promise<ExpenseByCategoryItem[]> => {
+    const result = await getPool().query<ExpenseByCategoryItem>(
+        `SELECT
+            category_id, name AS category_name, CAST(SUM(amount) AS FLOAT) AS total
+        FROM expenses
+        INNER JOIN categories ON expenses.category_id = categories.id
+        WHERE expenses.user_id = $1 AND TO_CHAR(date, 'YYYY-MM') = $2
+        GROUP BY category_id, category_name`,
         [user_id, month]
     );
     return result.rows;

--- a/backend/src/routes/expense.routes.ts
+++ b/backend/src/routes/expense.routes.ts
@@ -1,9 +1,10 @@
 import { Router } from "express";
-import { getExpensesByMonth, registerExpense } from "../controller/expense.controller.js";
+import { getExpensesByCategories, getExpensesByMonth, registerExpense } from "../controller/expense.controller.js";
 
 const router = Router();
 
 router.post('/expenses', registerExpense);
+router.get('/expenses/summary/:month', getExpensesByCategories);
 router.get('/expenses/:month', getExpensesByMonth);
 
 export default router;

--- a/backend/src/types/expense.types.ts
+++ b/backend/src/types/expense.types.ts
@@ -33,3 +33,9 @@ export type ExpenseItem = {
     category_id: string;
     category_name: string;
 }
+
+export type ExpenseByCategoryItem = {
+    category_id: string;
+    category_name: string;
+    total: number;
+}


### PR DESCRIPTION
### Description :
Implémentation de la route permettant de lister les dépenses d'un mois par catégories.
### Fichiers modifiés :
`expense.types.ts `— ajout du type `ExpenseByCategoryItem`
`expense.model.ts` — ajout de `findListExpenseByCategories` 
`expense.controller.ts` — ajout de `getExpensesByCategories`
`expense.routes.ts` — ajout de la route `GET /expenses/summary/:month`

### Tests à effectuer (Thunder Client) :

`GET /api/v1/expenses/summary/2026-04` → 200 + liste par catégories
`GET /api/v1/expenses/summary/2020-01` → 200 + tableau vide
`GET /api/v1/expenses/summary/avril-2026` → 400 + message d'erreur